### PR TITLE
MIN-930

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,17 @@ When creating tasks, you MUST provide:
 
 **Duration Format**: Use simple format like "30m", "1h", "1h30m" (NOT ISO PT prefix)
 
+## Security Posture
+
+The plugin implements several security layers:
+
+- **S1 — TLS enforcement:** API URLs must use HTTPS; plain HTTP is accepted only for `localhost` and `127.0.0.1`.
+- **S2 — No mass assignment:** Tool updates pass through an explicit field allowlist.
+- **S3 — Safe query parameters:** All query strings use proper URL encoding.
+- **S4 — Data minimization:** Memory search and credential handling avoid unnecessary data exposure.
+- **S5 — Tool result redaction:** Each tool result is recursively scanned for secret-shaped keys (accessToken, refreshToken, apiKey, secret, password, credential, etc.) and matching values are replaced with `[REDACTED]` before returning to OpenClaw. This is a backstop against server-side regressions.
+- **S6 — Visible degradation:** API failures are logged and never silently ignored.
+
 ## Skill Companion
 
 This plugin includes a companion skill at `skills/myn/SKILL.md` that teaches agents MYN workflow patterns including:

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,11 +109,39 @@ export class MynApiError extends Error {
   }
 }
 
+// MIN-930: Recursive redaction for secret-shaped keys
+const SECRET_KEY_PATTERN = /(?i)(access|refresh|id)_?token|secret|client_?secret|api_?key|password|credential/i;
+
+/**
+ * Recursively redact values whose keys match secret patterns. MIN-930 backstop.
+ */
+function redactSecrets(obj: unknown): unknown {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if (typeof obj === 'object' && Array.isArray(obj)) {
+    return obj.map((item) => redactSecrets(item));
+  }
+
+  if (typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = SECRET_KEY_PATTERN.test(key) ? '[REDACTED]' : redactSecrets(value);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
 /**
  * Helper to create a standardized tool result
  */
-export function jsonResult<T>(data: T): { success: true; data: T } {
-  return { success: true, data };
+export function jsonResult<T>(data: T): { success: true; data: unknown } {
+  // MIN-930: Redact secret-shaped keys from the result before returning to OpenClaw.
+  // This is a backstop against API regressions; server-side gates are the primary defense.
+  return { success: true, data: redactSecrets(data) };
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -110,7 +110,7 @@ export class MynApiError extends Error {
 }
 
 // MIN-930: Recursive redaction for secret-shaped keys
-const SECRET_KEY_PATTERN = /(?i)(access|refresh|id)_?token|secret|client_?secret|api_?key|password|credential/i;
+const SECRET_KEY_PATTERN = /(access|refresh|id)_?token|secret|client_?secret|api_?key|password|credential/i;
 
 /**
  * Recursively redact values whose keys match secret patterns. MIN-930 backstop.


### PR DESCRIPTION
**Issue:** #930

## Acceptance Criteria

- [ ] Delete refreshToken, expiresIn, tokenType from the profile payload
- [ ] Emit accessToken and expirationDate in the profile only for JWT-authenticated callers
- [ ] Remove stripeCustomerId and the tasks collection from the profile; gate stripeStatus to JWT
- [ ] Return a hand-built account map from POST /api/calendar/refreshTokens instead of the MYNCustomer entity
- [ ] Annotate Account.accessToken and Account.refreshToken with Jackson WRITE_ONLY
- [ ] Add CustomerSecretLeakRegressionTest: recursive secret-shaped-key walk over customer endpoint responses
- [ ] Audit every controller path that can reach an Account entity
- [ ] Recursive secret-key redaction in hermes-plugin tool_result and openclaw-plugin jsonResult
- [ ] Document the agent data-exposure rule across docs repo and plugin READMEs