### PR TITLE
MIN-932

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,8 @@ const client = new MynApiClient(
 );
 
 // Make authenticated requests
-const tasks = await client.get('/api/v2/unified-tasks');
+const taskPage = await client.get('/api/v2/unified-tasks?limit=20');
+const tasks = taskPage.tasks;
 const newTask = await client.post('/api/v2/unified-tasks', { ... });
 ```
 

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -85,44 +85,67 @@ async function remember(client: MynApiClient, input: MemoryInput) {
   return jsonResult(data);
 }
 
-/** Maximum number of memories to fetch from the backend */
+/** Maximum number of memories to fetch for a list response. */
 const MEMORY_FETCH_LIMIT = 50;
+const MEMORY_LOOKUP_PAGE_SIZE = 200;
+const MEMORY_LOOKUP_MAX_PAGES = 50;
+
+type MemoryDto = {
+  id: string;
+  type: string;
+  content: string;
+  confidence: number;
+  sourceConversationId: string | null;
+  sourceGoalId: string | null;
+  createdAt: string;
+  lastReinforcedAt: string | null;
+  reinforcementCount: number;
+  lastUsedAt: string | null;
+  usageCount: number;
+  topics: string[];
+  hasEmbedding: boolean;
+  confidenceLevel: string;
+};
+
+type MemoryPage = {
+  memories: MemoryDto[];
+  totalCount: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+};
 
 async function recall(client: MynApiClient, input: MemoryInput) {
-  const params = new URLSearchParams({ limit: String(input.limit ?? MEMORY_FETCH_LIMIT) });
-  const data = await client.get<{
-    memories: Array<{
-      id: string;
-      type: string;
-      content: string;
-      confidence: number;
-      sourceConversationId: string | null;
-      sourceGoalId: string | null;
-      createdAt: string;
-      lastReinforcedAt: string | null;
-      reinforcementCount: number;
-      lastUsedAt: string | null;
-      usageCount: number;
-      topics: string[];
-      hasEmbedding: boolean;
-      confidenceLevel: string;
-    }>;
-    totalCount: number;
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-  }>(`/api/v1/customers/memories?${params.toString()}`);
-  const memories = data.memories;
-
   if (input.memoryId) {
-    const match = memories.find(m => m.id === input.memoryId);
-    if (!match) {
-      return errorResult(`Memory not found: ${input.memoryId}`);
+    let offset = 0;
+    for (let page = 0; page < MEMORY_LOOKUP_MAX_PAGES; page += 1) {
+      const params = new URLSearchParams({
+        limit: String(MEMORY_LOOKUP_PAGE_SIZE),
+        offset: String(offset)
+      });
+      const data = await client.get<MemoryPage>(
+        `/api/v1/customers/memories?${params.toString()}`
+      );
+      const match = data.memories.find(memory => memory.id === input.memoryId);
+      if (match) {
+        return jsonResult(match);
+      }
+      if (!data.hasMore) {
+        return errorResult(`Memory not found: ${input.memoryId}`);
+      }
+      if (data.memories.length === 0) {
+        return errorResult('Memory lookup pagination did not advance');
+      }
+      offset += data.memories.length;
     }
-    return jsonResult(match);
+    return errorResult('Memory lookup reached its 50-page safety cap before completion');
   }
 
-  return jsonResult(memories);
+  const params = new URLSearchParams({ limit: String(input.limit ?? MEMORY_FETCH_LIMIT) });
+  const data = await client.get<MemoryPage>(
+    `/api/v1/customers/memories?${params.toString()}`
+  );
+  return jsonResult(data.memories);
 }
 
 async function forget(client: MynApiClient, input: MemoryInput) {

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -88,7 +88,6 @@ async function remember(client: MynApiClient, input: MemoryInput) {
 /** Maximum number of memories to fetch for a list response. */
 const MEMORY_FETCH_LIMIT = 50;
 const MEMORY_LOOKUP_PAGE_SIZE = 200;
-const MEMORY_LOOKUP_MAX_PAGES = 50;
 
 type MemoryDto = {
   id: string;
@@ -118,7 +117,16 @@ type MemoryPage = {
 async function recall(client: MynApiClient, input: MemoryInput) {
   if (input.memoryId) {
     let offset = 0;
-    for (let page = 0; page < MEMORY_LOOKUP_MAX_PAGES; page += 1) {
+    let page = 0;
+    let expectedPages: number | null = null;
+    const seenOffsets = new Set<number>();
+
+    while (expectedPages === null || page < expectedPages) {
+      if (seenOffsets.has(offset)) {
+        return errorResult('Memory lookup pagination did not advance');
+      }
+      seenOffsets.add(offset);
+
       const params = new URLSearchParams({
         limit: String(MEMORY_LOOKUP_PAGE_SIZE),
         offset: String(offset)
@@ -126,19 +134,29 @@ async function recall(client: MynApiClient, input: MemoryInput) {
       const data = await client.get<MemoryPage>(
         `/api/v1/customers/memories?${params.toString()}`
       );
+      if (expectedPages === null) {
+        if (!Number.isSafeInteger(data.totalCount) || data.totalCount < 0) {
+          return errorResult('Memory lookup returned an invalid totalCount');
+        }
+        expectedPages = Math.max(1, Math.ceil(data.totalCount / MEMORY_LOOKUP_PAGE_SIZE));
+      }
+
       const match = data.memories.find(memory => memory.id === input.memoryId);
       if (match) {
         return jsonResult(match);
       }
+
+      page += 1;
       if (!data.hasMore) {
         return errorResult(`Memory not found: ${input.memoryId}`);
       }
-      if (data.memories.length === 0) {
-        return errorResult('Memory lookup pagination did not advance');
+      if (data.memories.length === 0 || page >= expectedPages) {
+        return errorResult('Memory lookup pagination was inconsistent with totalCount');
       }
       offset += data.memories.length;
     }
-    return errorResult('Memory lookup reached its 50-page safety cap before completion');
+
+    return errorResult('Memory lookup pagination was inconsistent with totalCount');
   }
 
   const params = new URLSearchParams({ limit: String(input.limit ?? MEMORY_FETCH_LIMIT) });

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -92,13 +92,20 @@ async function recall(client: MynApiClient, input: MemoryInput) {
   const params = new URLSearchParams({ limit: String(input.limit ?? MEMORY_FETCH_LIMIT) });
   const data = await client.get<{
     memories: Array<{
-      memoryId: string;
+      id: string;
+      type: string;
       content: string;
-      category: string;
-      tags: string[];
-      importance: string;
+      confidence: number;
+      sourceConversationId: string | null;
+      sourceGoalId: string | null;
       createdAt: string;
-      accessedAt?: string;
+      lastReinforcedAt: string | null;
+      reinforcementCount: number;
+      lastUsedAt: string | null;
+      usageCount: number;
+      topics: string[];
+      hasEmbedding: boolean;
+      confidenceLevel: string;
     }>;
     totalCount: number;
     limit: number;
@@ -108,7 +115,7 @@ async function recall(client: MynApiClient, input: MemoryInput) {
   const memories = data.memories;
 
   if (input.memoryId) {
-    const match = memories.find(m => m.memoryId === input.memoryId);
+    const match = memories.find(m => m.id === input.memoryId);
     if (!match) {
       return errorResult(`Memory not found: ${input.memoryId}`);
     }

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -4,13 +4,13 @@
  * MIN-801: Now wired to real backend endpoints:
  * - remember → POST /api/v1/agent/memories
  * - search   → GET /api/v1/agent/memories/search
- * - recall   → GET /api/v1/customers/memories (unchanged)
+ * - recall   → GET /api/v1/customers/memories or /memories/{memoryId}
  * - forget   → DELETE /api/v1/customers/memories/{id} (unchanged)
  */
 
 import { Type } from '@sinclair/typebox';
 import type { MynApiClient } from '../client.js';
-import { jsonResult, errorResult } from '../client.js';
+import { MynApiError, jsonResult, errorResult } from '../client.js';
 
 export const MemoryInputSchema = Type.Object({
   action: Type.Union([
@@ -87,7 +87,6 @@ async function remember(client: MynApiClient, input: MemoryInput) {
 
 /** Maximum number of memories to fetch for a list response. */
 const MEMORY_FETCH_LIMIT = 50;
-const MEMORY_LOOKUP_PAGE_SIZE = 200;
 
 type MemoryDto = {
   id: string;
@@ -116,47 +115,20 @@ type MemoryPage = {
 
 async function recall(client: MynApiClient, input: MemoryInput) {
   if (input.memoryId) {
-    let offset = 0;
-    let page = 0;
-    let expectedPages: number | null = null;
-    const seenOffsets = new Set<number>();
-
-    while (expectedPages === null || page < expectedPages) {
-      if (seenOffsets.has(offset)) {
-        return errorResult('Memory lookup pagination did not advance');
-      }
-      seenOffsets.add(offset);
-
-      const params = new URLSearchParams({
-        limit: String(MEMORY_LOOKUP_PAGE_SIZE),
-        offset: String(offset)
-      });
-      const data = await client.get<MemoryPage>(
-        `/api/v1/customers/memories?${params.toString()}`
+    try {
+      const data = await client.get<MemoryDto>(
+        `/api/v1/customers/memories/${encodeURIComponent(input.memoryId)}`
       );
-      if (expectedPages === null) {
-        if (!Number.isSafeInteger(data.totalCount) || data.totalCount < 0) {
-          return errorResult('Memory lookup returned an invalid totalCount');
-        }
-        expectedPages = Math.max(1, Math.ceil(data.totalCount / MEMORY_LOOKUP_PAGE_SIZE));
+      if (data.id !== input.memoryId) {
+        return errorResult('Memory lookup returned an unexpected id');
       }
-
-      const match = data.memories.find(memory => memory.id === input.memoryId);
-      if (match) {
-        return jsonResult(match);
-      }
-
-      page += 1;
-      if (!data.hasMore) {
+      return jsonResult(data);
+    } catch (error) {
+      if (error instanceof MynApiError && error.statusCode === 404) {
         return errorResult(`Memory not found: ${input.memoryId}`);
       }
-      if (data.memories.length === 0 || page >= expectedPages) {
-        return errorResult('Memory lookup pagination was inconsistent with totalCount');
-      }
-      offset += data.memories.length;
+      throw error;
     }
-
-    return errorResult('Memory lookup pagination was inconsistent with totalCount');
   }
 
   const params = new URLSearchParams({ limit: String(input.limit ?? MEMORY_FETCH_LIMIT) });

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -89,9 +89,9 @@ async function remember(client: MynApiClient, input: MemoryInput) {
 const MEMORY_FETCH_LIMIT = 50;
 
 async function recall(client: MynApiClient, input: MemoryInput) {
-  const params = new URLSearchParams({ limit: String(MEMORY_FETCH_LIMIT) });
-  const data = await client.get<
-    Array<{
+  const params = new URLSearchParams({ limit: String(input.limit ?? MEMORY_FETCH_LIMIT) });
+  const data = await client.get<{
+    memories: Array<{
       memoryId: string;
       content: string;
       category: string;
@@ -99,11 +99,15 @@ async function recall(client: MynApiClient, input: MemoryInput) {
       importance: string;
       createdAt: string;
       accessedAt?: string;
-    }>
-  >(`/api/v1/customers/memories?${params.toString()}`);
+    }>;
+    totalCount: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  }>(`/api/v1/customers/memories?${params.toString()}`);
+  const memories = data.memories;
 
   if (input.memoryId) {
-    const memories = Array.isArray(data) ? data : [];
     const match = memories.find(m => m.memoryId === input.memoryId);
     if (!match) {
       return errorResult(`Memory not found: ${input.memoryId}`);
@@ -111,7 +115,7 @@ async function recall(client: MynApiClient, input: MemoryInput) {
     return jsonResult(match);
   }
 
-  return jsonResult(data);
+  return jsonResult(memories);
 }
 
 async function forget(client: MynApiClient, input: MemoryInput) {

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -57,7 +57,7 @@ export async function executeProjects(
 }
 
 async function listProjects(client: MynApiClient, input: ProjectsInput) {
-  const params = new URLSearchParams();
+  const params = new URLSearchParams({ limit: '50' });
 
   if (input.includeArchived) params.append('includeArchived', 'true');
   if (input.includeStats) params.append('includeStats', 'true');
@@ -67,21 +67,18 @@ async function listProjects(client: MynApiClient, input: ProjectsInput) {
   const data = await client.get<{
     projects: Array<{
       id: string;
-      name: string;
-      description?: string;
-      color?: string;
-      icon?: string;
-      parentId?: string;
-      createdAt: string;
-      stats?: {
-        totalTasks: number;
-        completedTasks: number;
-        criticalTasks: number;
-      };
+      type: string;
+      customName?: string;
+      customEmoji?: string;
+      hideTasksInMainList: boolean;
     }>;
+    total: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
   }>(`/api/project/defaults${queryString}`);
 
-  return jsonResult(data);
+  return jsonResult(data.projects);
 }
 
 async function getProject(client: MynApiClient, input: ProjectsInput) {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -110,12 +110,18 @@ async function listTasks(client: MynApiClient, input: TasksInput) {
   if (input.projectId) params.append('projectId', input.projectId);
   if (input.startDate) params.append('startDate', input.startDate);
   if (input.endDate) params.append('endDate', input.endDate);
-  if (input.limit) params.append('limit', input.limit.toString());
+  params.append('limit', String(input.limit ?? 20));
   if (input.offset) params.append('offset', input.offset.toString());
 
   const queryString = params.toString() ? `?${params.toString()}` : '';
-  const data = await client.get<unknown[]>(`/api/v2/unified-tasks${queryString}`);
-  return jsonResult(data);
+  const data = await client.get<{
+    tasks: unknown[];
+    total: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  }>(`/api/v2/unified-tasks${queryString}`);
+  return jsonResult(data.tasks);
 }
 
 async function getTask(client: MynApiClient, input: TasksInput) {

--- a/tests/integration/registration.test.ts
+++ b/tests/integration/registration.test.ts
@@ -28,6 +28,7 @@ const { MynApiClient } = await import('../../src/client.js');
 describe('Plugin Registration', () => {
   let mockApi: {
     registerTool: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
     logger: {
       debug: ReturnType<typeof vi.fn>;
       info: ReturnType<typeof vi.fn>;
@@ -40,6 +41,7 @@ describe('Plugin Registration', () => {
   beforeEach(() => {
     mockApi = {
       registerTool: vi.fn(),
+      on: vi.fn(),
       logger: {
         debug: vi.fn(),
         info: vi.fn(),
@@ -184,6 +186,11 @@ interface OpenClawPluginApi {
     inputSchema: unknown;
     execute: (input: unknown) => Promise<unknown>;
   }): void;
+  on(
+    hookName: string,
+    handler: (...args: unknown[]) => unknown,
+    opts?: { priority?: number }
+  ): void;
   logger: {
     debug(message: string): void;
     info(message: string): void;

--- a/tests/tools/calendar.test.ts
+++ b/tests/tools/calendar.test.ts
@@ -182,13 +182,25 @@ describe('myn_calendar', () => {
   describe('email validation in create_event', () => {
     it('skips invalid email attendees and only sends valid ones', async () => {
       mockFetch
-        // First call: resolve member emails (returns empty for non-email attendees)
+        // First call: resolve the non-email attendee against the current household
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ events: [], calendars: [] })
+          json: () => Promise.resolve({ id: 'household-1' })
         })
-        // Second call: create event
+        // Second call: no household member matches the invalid attendee name
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ members: [] })
+        })
+        // Third call: no shared calendar is available for the valid attendees
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ calendars: [] })
+        })
+        // Fourth call: create event
         .mockResolvedValueOnce({
           ok: true,
           status: 201,

--- a/tests/tools/debrief.test.ts
+++ b/tests/tools/debrief.test.ts
@@ -108,6 +108,18 @@ describe('myn_debrief', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should return the empty current response as data', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ current: null })
+      });
+
+      const result = await executeDebrief(client, { action: 'get' });
+
+      expect(result).toEqual({ success: true, data: { current: null } });
+    });
+
     it('should get specific briefing with id', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -130,98 +130,12 @@ describe('myn_memory', () => {
       expect(mockFetch.mock.calls[0][0]).toContain('limit=7');
     });
 
-    it('should get specific memory by id (client-side filter)', async () => {
+    it('should get a specific memory by customer-owned id', async () => {
+      const targetId = '550e8400-e29b-41d4-a716-446655440000';
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({
-          memories: [
-            memoryDto('550e8400-e29b-41d4-a716-446655440000', 'Specific memory')
-          ],
-          totalCount: 1,
-          limit: 200,
-          offset: 0,
-          hasMore: false
-        })
-      });
-
-      const result = await executeMemory(client, {
-        action: 'recall',
-        memoryId: '550e8400-e29b-41d4-a716-446655440000'
-      });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data).toHaveProperty('id', '550e8400-e29b-41d4-a716-446655440000');
-      }
-      expect(mockFetch.mock.calls[0][0]).toContain('limit=200&offset=0');
-    });
-
-    it('should scan later pages for an id regardless of the list limit', async () => {
-      const targetId = '550e8400-e29b-41d4-a716-446655440000';
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({
-            memories: Array.from({ length: 200 }, (_, index) =>
-              memoryDto(`other-${index}`, `Other memory ${index}`)
-            ),
-            totalCount: 201,
-            limit: 200,
-            offset: 0,
-            hasMore: true
-          })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({
-            memories: [memoryDto(targetId, 'Specific memory')],
-            totalCount: 201,
-            limit: 200,
-            offset: 200,
-            hasMore: false
-          })
-        });
-
-      const result = await executeMemory(client, {
-        action: 'recall',
-        memoryId: targetId,
-        limit: 1
-      });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data).toHaveProperty('id', targetId);
-      }
-      expect(mockFetch.mock.calls).toHaveLength(2);
-      expect(mockFetch.mock.calls[0][0]).toContain('limit=200&offset=0');
-      expect(mockFetch.mock.calls[1][0]).toContain('limit=200&offset=200');
-    });
-
-    it('should search beyond the former ten-thousand-memory cap', async () => {
-      const targetId = 'target-after-old-cap';
-      mockFetch.mockImplementation((url: string) => {
-        const offset = Number(new URL(url).searchParams.get('offset'));
-        const end = Math.min(offset + 200, 10_001);
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({
-            memories: Array.from({ length: end - offset }, (_, index) => {
-              const absoluteIndex = offset + index;
-              return memoryDto(
-                absoluteIndex === 10_000 ? targetId : `other-${absoluteIndex}`,
-                `Memory ${absoluteIndex}`
-              );
-            }),
-            totalCount: 10_001,
-            limit: 200,
-            offset,
-            hasMore: end < 10_001
-          })
-        });
+        json: () => Promise.resolve(memoryDto(targetId, 'Specific memory'))
       });
 
       const result = await executeMemory(client, {
@@ -233,7 +147,73 @@ describe('myn_memory', () => {
       if (result.success) {
         expect(result.data).toHaveProperty('id', targetId);
       }
-      expect(mockFetch.mock.calls).toHaveLength(51);
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect(mockFetch.mock.calls[0][0]).toContain(
+        `/api/v1/customers/memories/${targetId}`
+      );
+      expect(mockFetch.mock.calls[0][0]).not.toContain('?');
+    });
+
+    it('should ignore the list limit for direct id lookup', async () => {
+      const targetId = '550e8400-e29b-41d4-a716-446655440000';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(memoryDto(targetId, 'Specific memory'))
+      });
+
+      const result = await executeMemory(client, {
+        action: 'recall',
+        memoryId: targetId,
+        limit: 1
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect(mockFetch.mock.calls[0][0]).not.toContain('limit=');
+    });
+
+    it('should reject a mismatched direct lookup response', async () => {
+      const targetId = '550e8400-e29b-41d4-a716-446655440000';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(
+          memoryDto('660e8400-e29b-41d4-a716-446655440000', 'Wrong memory')
+        )
+      });
+
+      const result = await executeMemory(client, {
+        action: 'recall',
+        memoryId: targetId
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('unexpected id');
+      }
+      expect(mockFetch.mock.calls).toHaveLength(1);
+    });
+
+    it('should return a stable not-found error without scanning pages', async () => {
+      const targetId = '550e8400-e29b-41d4-a716-446655440000';
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: () => Promise.resolve('{"message":"Memory not found"}')
+      });
+
+      const result = await executeMemory(client, {
+        action: 'recall',
+        memoryId: targetId
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe(`Memory not found: ${targetId}`);
+      }
+      expect(mockFetch.mock.calls).toHaveLength(1);
     });
   });
 

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -29,7 +29,7 @@ describe('myn_memory', () => {
   beforeEach(() => {
     globalThis.fetch = mockFetch;
     client = new MynApiClient('https://api.mindyournow.com', 'test-key');
-    mockFetch.mockClear();
+    mockFetch.mockReset();
   });
 
   describe('remember action', () => {
@@ -164,8 +164,10 @@ describe('myn_memory', () => {
           ok: true,
           status: 200,
           json: () => Promise.resolve({
-            memories: [memoryDto('other', 'Other memory')],
-            totalCount: 2,
+            memories: Array.from({ length: 200 }, (_, index) =>
+              memoryDto(`other-${index}`, `Other memory ${index}`)
+            ),
+            totalCount: 201,
             limit: 200,
             offset: 0,
             hasMore: true
@@ -176,9 +178,9 @@ describe('myn_memory', () => {
           status: 200,
           json: () => Promise.resolve({
             memories: [memoryDto(targetId, 'Specific memory')],
-            totalCount: 2,
+            totalCount: 201,
             limit: 200,
-            offset: 1,
+            offset: 200,
             hasMore: false
           })
         });
@@ -195,7 +197,43 @@ describe('myn_memory', () => {
       }
       expect(mockFetch.mock.calls).toHaveLength(2);
       expect(mockFetch.mock.calls[0][0]).toContain('limit=200&offset=0');
-      expect(mockFetch.mock.calls[1][0]).toContain('limit=200&offset=1');
+      expect(mockFetch.mock.calls[1][0]).toContain('limit=200&offset=200');
+    });
+
+    it('should search beyond the former ten-thousand-memory cap', async () => {
+      const targetId = 'target-after-old-cap';
+      mockFetch.mockImplementation((url: string) => {
+        const offset = Number(new URL(url).searchParams.get('offset'));
+        const end = Math.min(offset + 200, 10_001);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            memories: Array.from({ length: end - offset }, (_, index) => {
+              const absoluteIndex = offset + index;
+              return memoryDto(
+                absoluteIndex === 10_000 ? targetId : `other-${absoluteIndex}`,
+                `Memory ${absoluteIndex}`
+              );
+            }),
+            totalCount: 10_001,
+            limit: 200,
+            offset,
+            hasMore: end < 10_001
+          })
+        });
+      });
+
+      const result = await executeMemory(client, {
+        action: 'recall',
+        memoryId: targetId
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveProperty('id', targetId);
+      }
+      expect(mockFetch.mock.calls).toHaveLength(51);
     });
   });
 

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -9,6 +9,22 @@ import { MynApiClient } from '../../src/client.js';
 describe('myn_memory', () => {
   const mockFetch = vi.fn();
   let client: MynApiClient;
+  const memoryDto = (id: string, content: string) => ({
+    id,
+    type: 'PREFERENCE',
+    content,
+    confidence: 0.9,
+    sourceConversationId: 'conversation-1',
+    sourceGoalId: null,
+    createdAt: '2026-03-01T10:00:00Z',
+    lastReinforcedAt: null,
+    reinforcementCount: 1,
+    lastUsedAt: null,
+    usageCount: 0,
+    topics: ['preference'],
+    hasEmbedding: true,
+    confidenceLevel: 'high'
+  });
 
   beforeEach(() => {
     globalThis.fetch = mockFetch;
@@ -79,9 +95,7 @@ describe('myn_memory', () => {
         ok: true,
         status: 200,
         json: () => Promise.resolve({
-          memories: [
-            { memoryId: '1', content: 'Memory 1', category: 'work_context', tags: [], importance: 'high', createdAt: '2026-03-01T10:00:00Z' }
-          ],
+          memories: [memoryDto('1', 'Memory 1')],
           totalCount: 1,
           limit: 50,
           offset: 0,
@@ -93,9 +107,7 @@ describe('myn_memory', () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data).toEqual([
-          { memoryId: '1', content: 'Memory 1', category: 'work_context', tags: [], importance: 'high', createdAt: '2026-03-01T10:00:00Z' }
-        ]);
+        expect(result.data).toEqual([memoryDto('1', 'Memory 1')]);
       }
       expect(mockFetch.mock.calls[0][0]).toContain('limit=50');
     });
@@ -124,15 +136,7 @@ describe('myn_memory', () => {
         status: 200,
         json: () => Promise.resolve({
           memories: [
-            {
-              memoryId: '550e8400-e29b-41d4-a716-446655440000',
-              content: 'Specific memory',
-              category: 'user_preference',
-              tags: ['pref'],
-              importance: 'medium',
-              createdAt: '2026-03-01T10:00:00Z',
-              accessedAt: '2026-03-01T12:00:00Z'
-            }
+            memoryDto('550e8400-e29b-41d4-a716-446655440000', 'Specific memory')
           ],
           totalCount: 1,
           limit: 50,
@@ -148,7 +152,7 @@ describe('myn_memory', () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data).toHaveProperty('memoryId', '550e8400-e29b-41d4-a716-446655440000');
+        expect(result.data).toHaveProperty('id', '550e8400-e29b-41d4-a716-446655440000');
       }
     });
   });

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -139,7 +139,7 @@ describe('myn_memory', () => {
             memoryDto('550e8400-e29b-41d4-a716-446655440000', 'Specific memory')
           ],
           totalCount: 1,
-          limit: 50,
+          limit: 200,
           offset: 0,
           hasMore: false
         })
@@ -154,6 +154,48 @@ describe('myn_memory', () => {
       if (result.success) {
         expect(result.data).toHaveProperty('id', '550e8400-e29b-41d4-a716-446655440000');
       }
+      expect(mockFetch.mock.calls[0][0]).toContain('limit=200&offset=0');
+    });
+
+    it('should scan later pages for an id regardless of the list limit', async () => {
+      const targetId = '550e8400-e29b-41d4-a716-446655440000';
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            memories: [memoryDto('other', 'Other memory')],
+            totalCount: 2,
+            limit: 200,
+            offset: 0,
+            hasMore: true
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            memories: [memoryDto(targetId, 'Specific memory')],
+            totalCount: 2,
+            limit: 200,
+            offset: 1,
+            hasMore: false
+          })
+        });
+
+      const result = await executeMemory(client, {
+        action: 'recall',
+        memoryId: targetId,
+        limit: 1
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveProperty('id', targetId);
+      }
+      expect(mockFetch.mock.calls).toHaveLength(2);
+      expect(mockFetch.mock.calls[0][0]).toContain('limit=200&offset=0');
+      expect(mockFetch.mock.calls[1][0]).toContain('limit=200&offset=1');
     });
   });
 

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -17,20 +17,28 @@ describe('myn_memory', () => {
   });
 
   describe('remember action', () => {
-    it('should return error — direct memory creation not supported by backend', async () => {
-      // The backend has no POST /memories endpoint; memories are created via AI conversations.
+    it('should create a memory through the agent endpoint', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          id: 'memory-1',
+          type: 'PREFERENCE',
+          content: 'User prefers morning meetings',
+          confidence: 1,
+          duplicate: false,
+          message: 'Created'
+        })
+      });
+
       const result = await executeMemory(client, {
         action: 'remember',
         content: 'User prefers morning meetings',
-        category: 'user_preference',
-        tags: ['meetings', 'preferences'],
-        importance: 'medium'
+        category: 'PREFERENCE'
       });
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('not supported');
-      }
+      expect(result.success).toBe(true);
+      expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/agent/memories');
     });
 
     it('should return error if content missing', async () => {
@@ -42,52 +50,95 @@ describe('myn_memory', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should return error even for minimal remember', async () => {
-      // Backend has no POST endpoint — always returns not-supported error.
+    it('should create a memory without an optional category', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          id: 'memory-1',
+          type: 'PREFERENCE',
+          content: 'Simple memory',
+          confidence: 1,
+          duplicate: false,
+          message: 'Created'
+        })
+      });
+
       const result = await executeMemory(client, {
         action: 'remember',
         content: 'Simple memory'
       });
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
   });
 
   describe('recall action', () => {
     it('should get recent memories', async () => {
-      // Backend returns an array of memory objects (not a wrapper object)
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve([
-          { memoryId: '1', content: 'Memory 1', category: 'work_context', tags: [], importance: 'high', createdAt: '2026-03-01T10:00:00Z' }
-        ])
+        json: () => Promise.resolve({
+          memories: [
+            { memoryId: '1', content: 'Memory 1', category: 'work_context', tags: [], importance: 'high', createdAt: '2026-03-01T10:00:00Z' }
+          ],
+          totalCount: 1,
+          limit: 50,
+          offset: 0,
+          hasMore: false
+        })
       });
 
       const result = await executeMemory(client, { action: 'recall' });
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(Array.isArray(result.data)).toBe(true);
+        expect(result.data).toEqual([
+          { memoryId: '1', content: 'Memory 1', category: 'work_context', tags: [], importance: 'high', createdAt: '2026-03-01T10:00:00Z' }
+        ]);
       }
+      expect(mockFetch.mock.calls[0][0]).toContain('limit=50');
     });
 
-    it('should get specific memory by id (client-side filter)', async () => {
-      // Backend returns all memories as array; client filters by memoryId
+    it('should use the requested recall limit', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve([
-          {
-            memoryId: '550e8400-e29b-41d4-a716-446655440000',
-            content: 'Specific memory',
-            category: 'user_preference',
-            tags: ['pref'],
-            importance: 'medium',
-            createdAt: '2026-03-01T10:00:00Z',
-            accessedAt: '2026-03-01T12:00:00Z'
-          }
-        ])
+        json: () => Promise.resolve({
+          memories: [],
+          totalCount: 0,
+          limit: 7,
+          offset: 0,
+          hasMore: false
+        })
+      });
+
+      await executeMemory(client, { action: 'recall', limit: 7 });
+
+      expect(mockFetch.mock.calls[0][0]).toContain('limit=7');
+    });
+
+    it('should get specific memory by id (client-side filter)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          memories: [
+            {
+              memoryId: '550e8400-e29b-41d4-a716-446655440000',
+              content: 'Specific memory',
+              category: 'user_preference',
+              tags: ['pref'],
+              importance: 'medium',
+              createdAt: '2026-03-01T10:00:00Z',
+              accessedAt: '2026-03-01T12:00:00Z'
+            }
+          ],
+          totalCount: 1,
+          limit: 50,
+          offset: 0,
+          hasMore: false
+        })
       });
 
       const result = await executeMemory(client, {

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MynApiClient } from '../../src/client.js';
+import { executeProjects } from '../../src/tools/projects.js';
+
+describe('myn_projects', () => {
+  const mockFetch = vi.fn();
+  let client: MynApiClient;
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch;
+    client = new MynApiClient('https://api.mindyournow.com', 'test-key');
+    mockFetch.mockClear();
+  });
+
+  it('lists projects with a limit and unwraps the projects envelope', async () => {
+    const projects = [
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        type: 'ALL',
+        customName: 'All tasks',
+        customEmoji: '📁',
+        hideTasksInMainList: false
+      }
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        projects,
+        total: 1,
+        limit: 50,
+        offset: 0,
+        hasMore: false
+      })
+    });
+
+    const result = await executeProjects(client, {
+      action: 'list',
+      includeArchived: true,
+      includeStats: true
+    });
+
+    expect(result).toEqual({ success: true, data: projects });
+    expect(mockFetch.mock.calls[0][0]).toContain('limit=50');
+    expect(mockFetch.mock.calls[0][0]).toContain('includeArchived=true');
+    expect(mockFetch.mock.calls[0][0]).toContain('includeStats=true');
+  });
+});

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -21,25 +21,41 @@ describe('myn_tasks', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve([
-          { id: '1', title: 'Task 1' },
-          { id: '2', title: 'Task 2' }
-        ])
+        json: () => Promise.resolve({
+          tasks: [
+            { id: '1', title: 'Task 1' },
+            { id: '2', title: 'Task 2' }
+          ],
+          total: 2,
+          limit: 20,
+          offset: 0,
+          hasMore: false
+        })
       });
 
       const result = await executeTasks(client, { action: 'list' });
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(Array.isArray(result.data)).toBe(true);
+        expect(result.data).toEqual([
+          { id: '1', title: 'Task 1' },
+          { id: '2', title: 'Task 2' }
+        ]);
       }
+      expect(mockFetch.mock.calls[0][0]).toContain('limit=20');
     });
 
     it('should list tasks with filters', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve([{ id: '1', priority: 'CRITICAL' }])
+        json: () => Promise.resolve({
+          tasks: [{ id: '1', priority: 'CRITICAL' }],
+          total: 1,
+          limit: 10,
+          offset: 0,
+          hasMore: false
+        })
       });
 
       await executeTasks(client, {


### PR DESCRIPTION
**Issue:** #932

## Acceptance Criteria

- [ ] Route ChoresController and ChoreAssignmentService customer resolution through the auth-agnostic resolver
- [ ] Make HouseholdMemberController GET members resolve API-key callers; regression-test HouseholdController /current
- [ ] Route CalendarV2Controller.getCurrentUserEmail through the auth-agnostic resolver
- [ ] Give GET /api/v2/calendar/events/{id} dual-id resolution with 400/404 semantics
- [ ] Add limit/offset envelope, compact UnifiedTaskSummaryDTO default, and detail=full to GET /api/v2/unified-tasks
- [ ] Return compact ProjectSummaryDTOs with limit/offset envelope from GET /api/project/defaults
- [ ] Honor limit/offset with pagination metadata on GET /api/v1/customers/memories
- [ ] Return 200 {"current": null} from debrief/current when no summary exists, and update its three callers
- [ ] Make application-dev.yml app.base-url env-driven and purge *.myn.localhost from env configs
- [ ] Update fe SyncService to paged detail=full envelope reads for the local-first cache
- [ ] Pass limit and unwrap envelopes in every remaining fe list caller (unified-tasks components + KaiaSettings memories)
- [ ] Pass limit and unwrap envelopes in hermes-plugin tasks/memory/projects list calls
- [ ] Pass limit and unwrap envelopes in openclaw-plugin tasks/memory/projects list calls
- [ ] Flip limit to required (400 naming the parameter) on the three list endpoints
- [ ] Update myn-skills API references and the endpoint catalog to the final contract