### PR TITLE
MIN-933

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,13 @@ action: members | invite | chores | chore_schedule | chore_complete
 ```
 
 ### myn_projects
-Manage projects and categories.
+Browse MYN collections and file tasks into them.
 
 ```yaml
-action: list | get | create | move_task
+action: list | get | move_task
 ```
+
+**Collections, not projects:** MYN has twelve fixed collections that cannot be created or deleted. Use `move_task` to re-file a task; real user-named projects are planned separately.
 
 ### myn_planning
 AI-powered planning and scheduling.

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -4,7 +4,7 @@
 
 import { Type } from '@sinclair/typebox';
 import type { MynApiClient } from '../client.js';
-import { jsonResult, errorResult } from '../client.js';
+import { errorResult, guardedPut, jsonResult } from '../client.js';
 
 export const ProjectsInputSchema = Type.Object({
   action: Type.Union([
@@ -107,12 +107,17 @@ async function moveTask(client: MynApiClient, input: ProjectsInput) {
     return errorResult('targetProjectId is required for move_task action');
   }
 
-  const data = await client.put<{
+  const data = await guardedPut<{
     taskId: string;
     previousProjectId?: string;
     newProjectId: string;
     moved: boolean;
-  }>(`/api/project/${input.targetProjectId}/moveTaskToProject/${input.taskId}`);
+  }>(
+    client,
+    `/api/project/${input.targetProjectId}/moveTaskToProject/${input.taskId}`,
+    undefined,
+    `/api/v2/unified-tasks/${input.taskId}`
+  );
 
   return jsonResult(data);
 }

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -10,23 +10,15 @@ export const ProjectsInputSchema = Type.Object({
   action: Type.Union([
     Type.Literal('list'),
     Type.Literal('get'),
-    Type.Literal('create'),
     Type.Literal('move_task')
   ]),
   // get parameters
   projectId: Type.Optional(Type.String({ format: 'uuid' })),
-  // create parameters
-  name: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
-  description: Type.Optional(Type.String({ maxLength: 500 })),
-  color: Type.Optional(Type.String({ pattern: '^#[0-9A-Fa-f]{6}$' })),
-  icon: Type.Optional(Type.String()),
-  parentProjectId: Type.Optional(Type.String({ format: 'uuid' })),
   // move_task parameters
   taskId: Type.Optional(Type.String({ format: 'uuid' })),
   targetProjectId: Type.Optional(Type.String({ format: 'uuid' })),
   // list parameters
-  includeArchived: Type.Optional(Type.Boolean({ default: false })),
-  includeStats: Type.Optional(Type.Boolean({ default: true }))
+  limit: Type.Optional(Type.Number({ minimum: 1, maximum: 200 }))
 });
 
 export type ProjectsInput = typeof ProjectsInputSchema.static;
@@ -41,8 +33,6 @@ export async function executeProjects(
         return await listProjects(client, input);
       case 'get':
         return await getProject(client, input);
-      case 'create':
-        return await createProject(client, input);
       case 'move_task':
         return await moveTask(client, input);
       default:
@@ -57,12 +47,8 @@ export async function executeProjects(
 }
 
 async function listProjects(client: MynApiClient, input: ProjectsInput) {
-  const params = new URLSearchParams({ limit: '50' });
-
-  if (input.includeArchived) params.append('includeArchived', 'true');
-  if (input.includeStats) params.append('includeStats', 'true');
-
-  const queryString = params.toString() ? `?${params.toString()}` : '';
+  const params = new URLSearchParams({ limit: String(input.limit ?? 50) });
+  const queryString = `?${params.toString()}`;
 
   const data = await client.get<{
     projects: Array<{
@@ -70,7 +56,8 @@ async function listProjects(client: MynApiClient, input: ProjectsInput) {
       type: string;
       customName?: string;
       customEmoji?: string;
-      hideTasksInMainList: boolean;
+      displayName: string;
+      taskCount: number;
     }>;
     total: number;
     limit: number;
@@ -111,29 +98,6 @@ async function getProject(client: MynApiClient, input: ProjectsInput) {
   return jsonResult(data);
 }
 
-async function createProject(client: MynApiClient, input: ProjectsInput) {
-  if (!input.name) {
-    return errorResult('name is required for create action');
-  }
-
-  const body: Record<string, unknown> = {
-    name: input.name
-  };
-
-  if (input.description) body.description = input.description;
-  if (input.color) body.color = input.color;
-  if (input.icon) body.icon = input.icon;
-  if (input.parentProjectId) body.parentId = input.parentProjectId;
-
-  const data = await client.post<{
-    id: string;
-    name: string;
-    created: boolean;
-  }>('/api/project/create', body);
-
-  return jsonResult(data);
-}
-
 async function moveTask(client: MynApiClient, input: ProjectsInput) {
   if (!input.taskId) {
     return errorResult('taskId is required for move_task action');
@@ -157,7 +121,7 @@ export function registerProjectsTool(api: OpenClawPluginApi, client: MynApiClien
   api.registerTool({
     id: 'myn_projects',
     name: 'MYN Projects',
-    description: 'Manage projects and categories. Actions: list, get, create, move_task.',
+    description: 'Browse MYN collections (called "projects" in the API) and file tasks into them. MYN has a fixed set of collections — PERSONAL, WORK, GROCERIES, BOOKS, CHORES, and so on. They cannot be created, renamed, or deleted; use move_task to change which collection a task belongs to. Actions: list, get, move_task.',
     inputSchema: ProjectsInputSchema,
     async execute(input: unknown) {
       return executeProjects(client, input as ProjectsInput);

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -60,6 +60,56 @@ describe('myn_projects', () => {
     expect(mockFetch.mock.calls[0][0]).toContain('limit=25');
   });
 
+  it('reads the task state hash before moving it', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          id: '22222222-2222-4222-8222-222222222222',
+          stateHash: 'task-hash-v1'
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          taskId: '22222222-2222-4222-8222-222222222222',
+          newProjectId: '11111111-1111-4111-8111-111111111111',
+          moved: true
+        })
+      });
+
+    const result = await executeProjects(client, {
+      action: 'move_task',
+      taskId: '22222222-2222-4222-8222-222222222222',
+      targetProjectId: '11111111-1111-4111-8111-111111111111'
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://api.mindyournow.com/api/v2/unified-tasks/22222222-2222-4222-8222-222222222222'
+    );
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({ method: 'GET' });
+    expect(mockFetch.mock.calls[1][0]).toBe(
+      'https://api.mindyournow.com/api/project/11111111-1111-4111-8111-111111111111/moveTaskToProject/22222222-2222-4222-8222-222222222222'
+    );
+    expect(mockFetch.mock.calls[1][1]).toMatchObject({
+      method: 'PUT',
+      headers: expect.objectContaining({
+        'X-MYN-State-Hash': 'task-hash-v1'
+      })
+    });
+    expect(result).toEqual({
+      success: true,
+      data: {
+        taskId: '22222222-2222-4222-8222-222222222222',
+        newProjectId: '11111111-1111-4111-8111-111111111111',
+        moved: true
+      }
+    });
+  });
+
   it('accepts exactly list, get, and move_task actions', () => {
     expect(Value.Check(ProjectsInputSchema, { action: 'list' })).toBe(true);
     expect(Value.Check(ProjectsInputSchema, { action: 'get' })).toBe(true);

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -1,6 +1,22 @@
+import { Value } from '@sinclair/typebox/value';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MynApiClient } from '../../src/client.js';
-import { executeProjects } from '../../src/tools/projects.js';
+import {
+  executeProjects,
+  ProjectsInputSchema,
+  registerProjectsTool
+} from '../../src/tools/projects.js';
+
+const DESCRIPTION = 'Browse MYN collections (called "projects" in the API) and file tasks into them. MYN has a fixed set of collections — PERSONAL, WORK, GROCERIES, BOOKS, CHORES, and so on. They cannot be created, renamed, or deleted; use move_task to change which collection a task belongs to. Actions: list, get, move_task.';
+const REMOVED_FIELDS = [
+  'name',
+  'description',
+  'color',
+  'icon',
+  'parentProjectId',
+  'includeArchived',
+  'includeStats'
+];
 
 describe('myn_projects', () => {
   const mockFetch = vi.fn();
@@ -12,14 +28,15 @@ describe('myn_projects', () => {
     mockFetch.mockClear();
   });
 
-  it('lists projects with a limit and unwraps the projects envelope', async () => {
+  it('lists compact project summaries with a requested limit', async () => {
     const projects = [
       {
         id: '11111111-1111-4111-8111-111111111111',
         type: 'ALL',
         customName: 'All tasks',
         customEmoji: '📁',
-        hideTasksInMainList: false
+        displayName: 'All tasks',
+        taskCount: 7
       }
     ];
     mockFetch.mockResolvedValueOnce({
@@ -28,7 +45,7 @@ describe('myn_projects', () => {
       json: () => Promise.resolve({
         projects,
         total: 1,
-        limit: 50,
+        limit: 25,
         offset: 0,
         hasMore: false
       })
@@ -36,13 +53,59 @@ describe('myn_projects', () => {
 
     const result = await executeProjects(client, {
       action: 'list',
-      includeArchived: true,
-      includeStats: true
+      limit: 25
     });
 
     expect(result).toEqual({ success: true, data: projects });
-    expect(mockFetch.mock.calls[0][0]).toContain('limit=50');
-    expect(mockFetch.mock.calls[0][0]).toContain('includeArchived=true');
-    expect(mockFetch.mock.calls[0][0]).toContain('includeStats=true');
+    expect(mockFetch.mock.calls[0][0]).toContain('limit=25');
+  });
+
+  it('accepts exactly list, get, and move_task actions', () => {
+    expect(Value.Check(ProjectsInputSchema, { action: 'list' })).toBe(true);
+    expect(Value.Check(ProjectsInputSchema, { action: 'get' })).toBe(true);
+    expect(Value.Check(ProjectsInputSchema, { action: 'move_task' })).toBe(true);
+    expect(Value.Check(ProjectsInputSchema, { action: 'create' })).toBe(false);
+  });
+
+  it('omits unsupported project fields from the schema', () => {
+    const fields = Object.keys(ProjectsInputSchema.properties);
+
+    for (const field of REMOVED_FIELDS) {
+      expect(fields).not.toContain(field);
+    }
+    expect(fields).toEqual([
+      'action',
+      'projectId',
+      'taskId',
+      'targetProjectId',
+      'limit'
+    ]);
+  });
+
+  it('rejects create without calling the API', async () => {
+    const result = await executeProjects(client, { action: 'create' } as never);
+
+    expect(result).toEqual({ success: false, error: 'Unknown action: create' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('registers the fixed-collections description verbatim', () => {
+    const registerTool = vi.fn();
+
+    registerProjectsTool({
+      registerTool,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+      }
+    }, client);
+
+    expect(registerTool).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'myn_projects',
+      description: DESCRIPTION,
+      inputSchema: ProjectsInputSchema
+    }));
   });
 });


### PR DESCRIPTION
**Issue:** #933

## Acceptance Criteria

- [ ] Sync all workspace repos to post-MIN-932 origin/main
- [ ] Make POST /api/project/create return 400 (never 500) and mark it deprecated
- [ ] Extend ProjectSummaryDTO with displayName + taskCount, drop hideTasksInMainList
- [ ] Fix useProjects to send limit and unwrap the /defaults envelope
- [ ] Hermes plugin: remove create from myn_projects and trim schema to stored fields
- [ ] OpenClaw plugin: remove create from myn_projects and sync response type to the new DTO
- [ ] Hermes plugin: route move_task through guarded_write with the task state hash
- [ ] OpenClaw plugin: route move_task through guardedPut with the task state hash
- [ ] Prove moveTaskToProject end to end with a self-cleaning API integration test
- [ ] Rewrite myn-skills projects-api.md as 'Collections, not projects'
- [ ] Update both plugin READMEs' myn_projects entries
- [ ] Update the docs-repo endpoint catalog: deprecate create, record Project-means-collection